### PR TITLE
Bump OpenTracing-api to 0.21.0.

### DIFF
--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractBasicTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractBasicTest.java
@@ -1,18 +1,16 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.tag.Tags;
+import org.junit.Assert;
+import org.junit.Test;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import io.opentracing.mock.MockSpan;
-import io.opentracing.tag.Tags;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * @author Pavol Loffay
@@ -73,7 +71,7 @@ public abstract class AbstractBasicTest extends AbstractJettyTest {
         Assert.assertEquals(6, clientSpan.tags().size());
         Assert.assertEquals(Tags.SPAN_KIND_CLIENT, clientSpan.tags().get(Tags.SPAN_KIND.getKey()));
         Assert.assertEquals("localhost", clientSpan.tags().get(Tags.PEER_HOSTNAME.getKey()));
-        Assert.assertEquals((short)getPort(), clientSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(getPort(), clientSpan.tags().get(Tags.PEER_PORT.getKey()));
         Assert.assertEquals("GET", clientSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(url("/hello"), clientSpan.tags().get(Tags.HTTP_URL.getKey()));
         Assert.assertEquals(200, clientSpan.tags().get(Tags.HTTP_STATUS.getKey()));

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientSpanDecorator.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientSpanDecorator.java
@@ -1,11 +1,11 @@
 package io.opentracing.contrib.jaxrs2.client;
 
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientResponseContext;
-
 import io.opentracing.Span;
 import io.opentracing.contrib.jaxrs2.internal.URIUtils;
 import io.opentracing.tag.Tags;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
 
 /**
  * @author Pavol Loffay
@@ -38,7 +38,7 @@ public interface ClientSpanDecorator {
         @Override
         public void decorateRequest(ClientRequestContext requestContext, Span span) {
             Tags.PEER_HOSTNAME.set(span, requestContext.getUri().getHost());
-            Tags.PEER_PORT.set(span, (short)requestContext.getUri().getPort());
+            Tags.PEER_PORT.set(span, requestContext.getUri().getPort());
 
             Tags.HTTP_METHOD.set(span, requestContext.getMethod());
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Versions -->
-    <version.io.opentracing-opentracing>0.20.9</version.io.opentracing-opentracing>
+    <version.io.opentracing-opentracing>0.21.0</version.io.opentracing-opentracing>
     <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.0.2</version.io.opentracing.contrib-opentracing-web-servlet-filter>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.javax.servlet-api>3.1.0</version.javax.servlet-api>


### PR DESCRIPTION
This changes Tag.PEER_PORT from short to int.