### PR TITLE
Bump servlet filter to 0.0.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <!-- Versions -->
     <version.io.opentracing-opentracing>0.21.0</version.io.opentracing-opentracing>
-    <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.0.2</version.io.opentracing.contrib-opentracing-web-servlet-filter>
+    <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.0.6</version.io.opentracing.contrib-opentracing-web-servlet-filter>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.javax.servlet-api>3.1.0</version.javax.servlet-api>
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
Instrumentation stack should use the same OT version.