### PR TITLE
Improve creation of jax-rs features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,18 @@
 
 # OpenTracing JAX-RS Instrumentation
 
-OpenTracing instrumentation for JAX-RS standard.
-It supports server and client request tracing.
+OpenTracing instrumentation for JAX-RS standard. It supports server and client request tracing.
 
 Instrumentation by default adds set of standard tags and sets span operation name with HTTP method. 
 This can be overridden by span decorators.
 
 ## Tracing Server Requests
 ```java
-// register this in javax.ws.rs.core.Application
-ServerTracingDynamicFeature.Builder
-    .traceAll(yourPreferredTracer)
+DynamicFeature dynamicFeafure = new ServerTracingDynamicFeature.Builder(tracer)
     .withDecorators(Arrays.asList(ServerSpanDecorator.HTTP_WILDCARD_PATH_OPERATION_NAME, 
                                   ServerSpanDecorator.STANDARD_TAGS))
     .build();
+// register this in javax.ws.rs.core.Application
 
 @GET
 @Path("/hello")
@@ -35,10 +33,8 @@ public Response hello(@BeanParam ServerSpanContext serverSpanContext) {
 
 ## Tracing Client Requests
 ```java
-ClientTracingFeature.Builder
-    .traceAll(yourPreferredTracer, jaxRsClient)
-    .withDecorators(Arrays.asList(ServerSpanDecorator.HTTP_PATH_OPERATION_NAME))
-    .build();
+Client client = ClientBuilder.newClient();
+client.register(ClientTracingFeature.class);
 
 Response response = jaxRsClient.target("http://localhost/endpoint")
     .request()

--- a/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/JerseyConfig.java
+++ b/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/JerseyConfig.java
@@ -1,17 +1,16 @@
 package io.opentracing.contrib.jaxrs2.example.spring.boot;
 
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
+import io.opentracing.contrib.jaxrs2.itest.common.rest.TestHandler;
+import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
-
 import org.glassfish.jersey.server.ResourceConfig;
 import org.springframework.stereotype.Component;
-
-import io.opentracing.Tracer;
-import io.opentracing.contrib.jaxrs2.itest.common.rest.TestHandler;
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
-import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 
 /**
  * @author Pavol Loffay
@@ -23,13 +22,9 @@ public class JerseyConfig extends ResourceConfig {
     @Inject
     public JerseyConfig(Tracer tracer) {
         Client client = ClientBuilder.newClient();
+        client.register(new ClientTracingFeature(new Builder(tracer)));
 
-        ClientTracingFeature.Builder
-                .traceAll(tracer, client)
-                .build();
-
-        register(ServerTracingDynamicFeature.Builder
-                .traceAll(tracer)
+        register(new ServerTracingDynamicFeature.Builder(tracer)
                 .build());
 
         register(new TestHandler(tracer, client));

--- a/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/JerseyConfig.java
+++ b/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/JerseyConfig.java
@@ -1,7 +1,6 @@
 package io.opentracing.contrib.jaxrs2.example.spring.boot;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
 import io.opentracing.contrib.jaxrs2.itest.common.rest.TestHandler;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
@@ -22,7 +21,7 @@ public class JerseyConfig extends ResourceConfig {
     @Inject
     public JerseyConfig(Tracer tracer) {
         Client client = ClientBuilder.newClient();
-        client.register(new ClientTracingFeature(new Builder(tracer)));
+        client.register(new Builder(tracer).build());
 
         register(new ServerTracingDynamicFeature.Builder(tracer)
                 .build());

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
@@ -1,6 +1,8 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
 
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
 import java.util.List;
 
 import javax.ws.rs.client.Client;
@@ -13,7 +15,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
@@ -23,8 +24,9 @@ import io.opentracing.mock.MockTracer;
  */
 public abstract class AbstractJettyTest {
 
-    public static final String TRACER_BUILDER_ATTRIBUTE = "tracerBuilder";
-    public static final String CLIENT_BUILDER_ATTRIBUTE = "clientBuilder";
+    public static final String SERVER_TRACING_FEATURE = "serveTracingFeature";
+    public static final String CLIENT_ATTRIBUTE = "clientBuilder";
+    public static final String TRACER_ATTRIBUTE = "tracer";
 
     protected Server jettyServer;
     protected MockTracer mockTracer;
@@ -33,14 +35,15 @@ public abstract class AbstractJettyTest {
     protected abstract void initServletContext(ServletContextHandler context);
 
     protected void initTracing(ServletContextHandler context) {
-        ClientTracingFeature.Builder clientTracingBuilder = ClientTracingFeature.Builder
-                .traceAll(mockTracer, client);
+        client.register(new ClientTracingFeature(new Builder(mockTracer)));
 
-        ServerTracingDynamicFeature.Builder serverTracingBuilder = ServerTracingDynamicFeature.Builder
-                .traceAll(mockTracer);
+        ServerTracingDynamicFeature serverTracingFeature =
+            new ServerTracingDynamicFeature.Builder(mockTracer)
+            .build();
 
-        context.setAttribute(CLIENT_BUILDER_ATTRIBUTE, clientTracingBuilder);
-        context.setAttribute(TRACER_BUILDER_ATTRIBUTE, serverTracingBuilder);
+        context.setAttribute(CLIENT_ATTRIBUTE, client);
+        context.setAttribute(TRACER_ATTRIBUTE, mockTracer);
+        context.setAttribute(SERVER_TRACING_FEATURE, serverTracingFeature);
     }
 
     @Before

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
@@ -1,23 +1,19 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
 
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
+import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
 import java.util.List;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
-
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-
-import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
-import io.opentracing.mock.MockSpan;
-import io.opentracing.mock.MockTracer;
 
 /**
  * @author Pavol Loffay
@@ -35,7 +31,7 @@ public abstract class AbstractJettyTest {
     protected abstract void initServletContext(ServletContextHandler context);
 
     protected void initTracing(ServletContextHandler context) {
-        client.register(new ClientTracingFeature(new Builder(mockTracer)));
+        client.register(new Builder(mockTracer).build());
 
         ServerTracingDynamicFeature serverTracingFeature =
             new ServerTracingDynamicFeature.Builder(mockTracer)

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
@@ -1,21 +1,17 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
-
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.opentracing.contrib.jaxrs2.server.ServerSpanDecorator;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import io.opentracing.mock.MockSpan;
+import java.util.Arrays;
+import java.util.List;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author Pavol Loffay
@@ -24,7 +20,7 @@ public abstract class AbstractWildcardOperationNameTest extends AbstractJettyTes
 
     @Override
     protected void initTracing(ServletContextHandler context) {
-        client.register(new ClientTracingFeature(new Builder(mockTracer)));
+        client.register(new Builder(mockTracer).build());
 
         ServerTracingDynamicFeature serverTracingBuilder =
             new ServerTracingDynamicFeature.Builder(mockTracer)

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
@@ -1,5 +1,7 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
+import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature.Builder;
 import java.util.Arrays;
 import java.util.List;
 
@@ -11,7 +13,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 import io.opentracing.contrib.jaxrs2.server.ServerSpanDecorator;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import io.opentracing.mock.MockSpan;
@@ -23,15 +24,16 @@ public abstract class AbstractWildcardOperationNameTest extends AbstractJettyTes
 
     @Override
     protected void initTracing(ServletContextHandler context) {
-        ClientTracingFeature.Builder clientTracingBuilder = ClientTracingFeature.Builder
-                .traceAll(mockTracer, client);
+        client.register(new ClientTracingFeature(new Builder(mockTracer)));
 
-        ServerTracingDynamicFeature.Builder serverTracingBuilder = ServerTracingDynamicFeature.Builder
-                .traceAll(mockTracer)
-                .withDecorators(Arrays.asList(ServerSpanDecorator.HTTP_WILDCARD_PATH_OPERATION_NAME));
+        ServerTracingDynamicFeature serverTracingBuilder =
+            new ServerTracingDynamicFeature.Builder(mockTracer)
+                .withDecorators(Arrays.asList(ServerSpanDecorator.HTTP_WILDCARD_PATH_OPERATION_NAME))
+            .build();
 
-        context.setAttribute(CLIENT_BUILDER_ATTRIBUTE, clientTracingBuilder);
-        context.setAttribute(TRACER_BUILDER_ATTRIBUTE, serverTracingBuilder);
+        context.setAttribute(TRACER_ATTRIBUTE, mockTracer);
+        context.setAttribute(CLIENT_ATTRIBUTE, client);
+        context.setAttribute(SERVER_TRACING_FEATURE, serverTracingBuilder);
     }
 
     @Test

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
@@ -1,28 +1,45 @@
 package io.opentracing.contrib.jaxrs2.client;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.ws.rs.client.Client;
-
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
 
 /**
  * @author Pavol Loffay
  */
-public class ClientTracingFeature {
-
+@Provider
+public class ClientTracingFeature implements Feature {
     private static final Logger log = Logger.getLogger(ClientTracingFeature.class.getName());
 
-    private ClientTracingFeature(Builder builder) {
-        if (log.isLoggable(Level.INFO)) {
-            log.info("Registering client tracing for: " + builder.client);
-        }
+    private Builder builder;
 
-        builder.client.register(new SpanClientRequestFilter(builder.tracer, builder.spanDecorators), 0)
-                .register(new SpanClientResponseFilter(builder.spanDecorators), 0);
+    /**
+     * When using this constructor application has to call {@link GlobalTracer#register} to register
+     * tracer instance.
+     */
+    public ClientTracingFeature() {
+        this(new Builder(GlobalTracer.get()));
+    }
+
+    public ClientTracingFeature(Builder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        log.info("Registering client OpenTracing, with configuration:" + builder.toString());
+        context.register(new SpanClientRequestFilter(builder.tracer, builder.spanDecorators),
+            builder.priority);
+        context.register(new SpanClientResponseFilter(builder.spanDecorators),
+            builder.priority);
+        return true;
     }
 
     /**
@@ -33,23 +50,14 @@ public class ClientTracingFeature {
      */
     public static class Builder {
         private Tracer tracer;
-        private Client client;
         private List<ClientSpanDecorator> spanDecorators;
+        private int priority;
 
-        private Builder(Tracer tracer, Client client) {
+        public Builder(Tracer tracer) {
             this.tracer = tracer;
-            this.client = client;
-            this.spanDecorators = Arrays.asList(ClientSpanDecorator.STANDARD_TAGS);
-        }
-
-        /**
-         * @param tracer tracer instance
-         * @param client client instance
-         * @return builder
-         */
-        public static Builder traceAll(Tracer tracer, Client client) {
-            Builder builder = new Builder(tracer, client);
-            return builder;
+            this.spanDecorators = Collections.singletonList(ClientSpanDecorator.STANDARD_TAGS);
+            // by default do not use Priorities.AUTHENTICATION due to security concerns
+            this.priority = Priorities.HEADER_DECORATOR;
         }
 
         /**
@@ -57,31 +65,27 @@ public class ClientTracingFeature {
          * @return builder
          */
         public Builder withDecorators(List<ClientSpanDecorator> spanDecorators) {
-            this.spanDecorators= spanDecorators;
+            this.spanDecorators = spanDecorators;
             return this;
         }
 
         /**
-         * @return passed tracer instance
+         * @param priority the overriding priority for the registered component.
+         *                 Default is {@link Priorities#HEADER_DECORATOR}
+         * @return builder
+         *
+         * @see Priorities
          */
-        public Tracer tracer() {
-            return tracer;
+        public Builder withPriority(int priority) {
+            this.priority = priority;
+            return this;
         }
 
         /**
-         * @return passed client instance
+         * @return client tracing feature. This feature should be manually registered to {@link Client}
          */
-        public Client client() {
-            return client;
-        }
-
-        /**
-         * Registers tracing filters.
-         * @return client
-         */
-        public Client build() {
-            new ClientTracingFeature(this);
-            return client;
+        public ClientTracingFeature build() {
+            return new ClientTracingFeature(this);
         }
     }
 }

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
@@ -23,12 +23,14 @@ public class ClientTracingFeature implements Feature {
     /**
      * When using this constructor application has to call {@link GlobalTracer#register} to register
      * tracer instance.
+     *
+     * For a custom configuration use {@link Builder#build()}.
      */
     public ClientTracingFeature() {
         this(new Builder(GlobalTracer.get()));
     }
 
-    public ClientTracingFeature(Builder builder) {
+    private ClientTracingFeature(Builder builder) {
         this.builder = builder;
     }
 

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/SpanClientRequestFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/SpanClientRequestFilter.java
@@ -1,14 +1,5 @@
 package io.opentracing.contrib.jaxrs2.client;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -16,10 +7,20 @@ import io.opentracing.contrib.jaxrs2.internal.CastUtils;
 import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
 
 /**
  * @author Pavol Loffay
  */
+@Priority(Priorities.HEADER_DECORATOR)
 public class SpanClientRequestFilter implements ClientRequestFilter {
 
     private static final Logger log = Logger.getLogger(SpanClientRequestFilter.class.getName());

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/SpanClientResponseFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/SpanClientResponseFilter.java
@@ -1,20 +1,21 @@
 package io.opentracing.contrib.jaxrs2.client;
 
+import io.opentracing.contrib.jaxrs2.internal.CastUtils;
+import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
 
-import io.opentracing.contrib.jaxrs2.internal.CastUtils;
-import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
-
 /**
  * @author Pavol Loffay
  */
+@Priority(Priorities.HEADER_DECORATOR)
 public class SpanClientResponseFilter implements ClientResponseFilter {
 
     private static final Logger log = Logger.getLogger(SpanClientResponseFilter.class.getName());

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/TracingProperties.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/TracingProperties.java
@@ -10,18 +10,17 @@ public class TracingProperties {
     private TracingProperties() {}
 
     /**
-     * Denotes a "parent" get ({@link io.opentracing.References#CHILD_OF}).
+     * Denotes a parent span context {@link io.opentracing.References#CHILD_OF}.
      * If it is not specified a new trace will be started.
-     * Value should be {@link io.opentracing.SpanContext}.
-     * Set on {@link javax.ws.rs.client.Client#property(String, Object)}.
+     * Set on {@link javax.ws.rs.client.Invocation#property(String, Object)}.
      */
     public static final String CHILD_OF = SpanClientRequestFilter.class.getName() + "." + References.CHILD_OF;
 
     /**
      * Indicates whether request should be traced or not. If it is not
-     * present and client is correctly configured requests will be traced.
-     * Value should be boolean true or false (trace disabled/enabled).
-     * Set on {@link javax.ws.rs.client.Client#property(String, Object)}.
+     * present and client is correctly configured request will be traced.
+     * Value should be a boolean (trace disabled/enabled).
+     * Set on {@link javax.ws.rs.client.Invocation#property(String, Object)}.
      */
     public static final String TRACING_DISABLED = SpanClientRequestFilter.class.getName() + ".tracingDisabled";
 }

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
@@ -28,12 +28,14 @@ public class ServerTracingDynamicFeature implements DynamicFeature {
     /**
      * When using this constructor application has to call {@link GlobalTracer#register} to register
      * tracer instance. Ideally it should be called in {@link javax.servlet.ServletContextListener}.
+     *
+     * For a custom configuration use {@link Builder#build()}.
      */
     public ServerTracingDynamicFeature() {
         this(new Builder(GlobalTracer.get()));
     }
 
-    public ServerTracingDynamicFeature(Builder builder) {
+    private ServerTracingDynamicFeature(Builder builder) {
         this.builder = builder;
     }
 

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/Traced.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/Traced.java
@@ -6,7 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to explicitly say that tracing is enabled.
+ * Annotation to explicitly say that tracing is enabled. It is also used to override span's
+ * operation name.
  *
  * @author Pavol Loffay
  */


### PR DESCRIPTION
* Simplify registration of client filters by `client.register(clientFeafure)` client feature can be provided as a class or instance with custom configuration.
* Added `@Priority` to client filters.
* Simplified construction of server feature builder.
