### PR TITLE
Gracefully handle the request context not having a span

### DIFF
--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerTest.java
@@ -127,4 +127,17 @@ public abstract class AbstractServerTest extends AbstractJettyTest {
         assertOnErrors(mockTracer.finishedSpans());
         Assert.assertEquals("GET", mockSpans.get(0).operationName());
     }
+
+    @Test
+    public void testRequestBlockedByFilter() throws Exception {
+        Client client = ClientBuilder.newClient();
+        Response response = client.target(url("/filtered"))
+                .request()
+                .get();
+        response.close();
+        Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(0, mockSpans.size());
+    }
 }

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/rest/TestHandler.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/rest/TestHandler.java
@@ -108,6 +108,13 @@ public class TestHandler {
         return Response.seeOther(URI.create("http://" + url)).build();
     }
 
+    @GET
+    @Path("/filtered")
+    public Response filtered() {
+        // Should never reach here.
+        return Response.ok().build();
+    }
+
     private class ExpensiveOperation implements Runnable {
 
         private AsyncResponse asyncResponse;

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
@@ -89,6 +89,9 @@ public class ServerTracingFilter implements ContainerRequestFilter, ContainerRes
             throws IOException {
         SpanWrapper spanWrapper = CastUtils.cast(
             requestContext.getProperty(ServerTracingFilter.SPAN_PROP_ID), SpanWrapper.class);
+        if (spanWrapper == null) {
+            return;
+        }
 
         if (spanDecorators != null) {
             for (ServerSpanDecorator decorator: spanDecorators) {


### PR DESCRIPTION
If the request is rejected by a filter that executes before the
ServerTracingFilter, it's possible for the request context to not
contain a SpanWrapper in the SPAN_PROP_ID property.

Signed-off-by: Maxime Petazzoni <maxime.petazzoni@bulix.org>