### PR TITLE
Public client filter const, url with query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status][ci-img]][ci] [![Released Version][maven-img]][maven]
 
 # OpenTracing JAX-RS Instrumentation
-
 OpenTracing instrumentation for JAX-RS standard. It supports tracing of server and client requests.
 
 Instrumentation by default adds a set of standard HTTP tags and as an operation name it uses a string defined in `@Path` annotation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status][ci-img]][ci] [![Released Version][maven-img]][maven]
 
 # OpenTracing JAX-RS Instrumentation
+
 OpenTracing instrumentation for JAX-RS standard. It supports tracing of server and client requests.
 
 Instrumentation by default adds a set of standard HTTP tags and as an operation name it uses a string defined in `@Path` annotation.

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractServerTest extends AbstractJettyTest {
     @Test
     public void testServerStandardTags() throws Exception {
         Client client = ClientBuilder.newClient();
-        Response response = client.target(url("/hello/1"))
+        Response response = client.target(url("/hello/1?q=a"))
             .request()
             .get();
         response.close();
@@ -37,7 +37,7 @@ public abstract class AbstractServerTest extends AbstractJettyTest {
         Assert.assertEquals("GET", mockSpan.operationName());
         Assert.assertEquals(4, mockSpan.tags().size());
         Assert.assertEquals(Tags.SPAN_KIND_SERVER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
-        Assert.assertEquals(url("/hello/1"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(url("/hello/1?q=a"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
         Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
     }

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFilter.java
@@ -32,7 +32,7 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
     private Tracer tracer;
     private List<ClientSpanDecorator> spanDecorators;
 
-    protected ClientTracingFilter(Tracer tracer, List<ClientSpanDecorator> spanDecorators) {
+    public ClientTracingFilter(Tracer tracer, List<ClientSpanDecorator> spanDecorators) {
         this.tracer = tracer;
         this.spanDecorators = new ArrayList<>(spanDecorators);
     }

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerSpanDecorator.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerSpanDecorator.java
@@ -37,7 +37,7 @@ public interface ServerSpanDecorator {
         public void decorateRequest(ContainerRequestContext requestContext, BaseSpan<?> span) {
             Tags.HTTP_METHOD.set(span, requestContext.getMethod());
 
-            String url = URIUtils.url(requestContext.getUriInfo().getAbsolutePath());
+            String url = URIUtils.url(requestContext.getUriInfo().getRequestUri());
             if (url != null) {
                 Tags.HTTP_URL.set(span, url);
             }


### PR DESCRIPTION
* MP uses the full URL in the `http.url` tag
* I need to instantiate client filter manually in swarm integration