### PR TITLE
Fix serialization priority builder field

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/client/ClientTracingFeature.java
@@ -105,14 +105,14 @@ public class ClientTracingFeature implements Feature {
         }
 
         /**
-         * @param priority the overriding priority for the registered component.
-         *                 Default is {@link Priorities#ENTITY_CODER}
+         * @param serializationPriority the overriding priority for the registered component.
+         *                              Default is {@link Priorities#ENTITY_CODER}
          * @return builder
          *
          * @see Priorities
          */
-        public Builder withSerializationPriority(int priority) {
-            this.priority = priority;
+        public Builder withSerializationPriority(int serializationPriority) {
+            this.serializationPriority = serializationPriority;
             return this;
         }
 

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
@@ -164,14 +164,14 @@ public class ServerTracingDynamicFeature implements DynamicFeature {
         }
 
         /**
-         * @param priority the overriding priority for the registered component.
-         *                 Default is {@link Priorities#ENTITY_CODER}
+         * @param serializationPriority the overriding priority for the registered component.
+         *                              Default is {@link Priorities#ENTITY_CODER}
          * @return builder
          *
          * @see Priorities
          */
-        public Builder withSerializationPriority(int priority) {
-            this.priority = priority;
+        public Builder withSerializationPriority(int serializationPriority) {
+            this.serializationPriority = serializationPriority;
             return this;
         }
 


### PR DESCRIPTION
Seems like this is what should be happening? (judging from the method name)
Currently you can't set the serializationPriority from the builder.