### PR TITLE
using active span if exists instead of extracting from http headers

### DIFF
--- a/opentracing-jaxrs2-itest/apache-cxf/src/test/java/io/opentracing/contrib/jaxrs2/itest/cxf/ApacheCXFParentSpanResolutionTest.java
+++ b/opentracing-jaxrs2-itest/apache-cxf/src/test/java/io/opentracing/contrib/jaxrs2/itest/cxf/ApacheCXFParentSpanResolutionTest.java
@@ -1,0 +1,13 @@
+package io.opentracing.contrib.jaxrs2.itest.cxf;
+
+import io.opentracing.contrib.jaxrs2.itest.common.AbstractParentSpanResolutionTest;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+public class ApacheCXFParentSpanResolutionTest extends AbstractParentSpanResolutionTest {
+
+  @Override
+  protected void initServletContext(ServletContextHandler context) {
+    super.initServletContext(context);
+    ApacheCXFHelper.initServletContext(context);
+  }
+}

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractParentSpanResolutionTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractParentSpanResolutionTest.java
@@ -1,0 +1,78 @@
+package io.opentracing.contrib.jaxrs2.itest.common;
+
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.tag.Tags;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.*;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.awaitility.Awaitility.await;
+
+public abstract class AbstractParentSpanResolutionTest extends AbstractJettyTest {
+
+    @Override
+    protected void initServletContext(ServletContextHandler context) {
+        context.addFilter(new FilterHolder(new FilterThatInitsSpan()), "/*",
+                EnumSet.of(
+                        DispatcherType.REQUEST,
+                        DispatcherType.FORWARD,
+                        // TODO CXF does not call AsyncListener#onComplete() without this (it calls only onStartAsync)
+                        DispatcherType.ASYNC,
+                        DispatcherType.ERROR,
+                        DispatcherType.INCLUDE
+                )
+        );
+    }
+
+    @Test
+    public void test() {
+        Client client = ClientBuilder.newClient();
+        Response response = client.target(url("/hello/1"))
+                .request()
+                .get();
+        response.close();
+        await().until(finishedSpansSizeEquals(2));
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+
+        Assert.assertEquals(2, spans.size());
+
+        MockSpan preceding = getSpanWithTag(spans, new ImmutableTag(Tags.COMPONENT.getKey(), "preceding-opentracing-filter"));
+        MockSpan original = getSpanWithTag(spans, new ImmutableTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER));
+
+        Assert.assertEquals(preceding.context().spanId(), original.parentId());
+    }
+
+    class FilterThatInitsSpan implements Filter {
+
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            Scope scope = mockTracer.buildSpan("initializing-span")
+                    .withTag(Tags.COMPONENT.getKey(), "preceding-opentracing-filter")
+                    .startActive(true);
+            chain.doFilter(request, response);
+            scope.close();
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+    }
+}

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractParentSpanResolutionTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractParentSpanResolutionTest.java
@@ -1,5 +1,7 @@
 package io.opentracing.contrib.jaxrs2.itest.common;
 
+import static org.awaitility.Awaitility.await;
+
 import io.opentracing.Scope;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.tag.Tags;
@@ -8,15 +10,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.servlet.*;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.awaitility.Awaitility.await;
+import javax.servlet.*;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 
 public abstract class AbstractParentSpanResolutionTest extends AbstractJettyTest {
 
@@ -35,7 +36,7 @@ public abstract class AbstractParentSpanResolutionTest extends AbstractJettyTest
     }
 
     @Test
-    public void test() {
+    public void testUseActiveSpanIfSet() {
         Client client = ClientBuilder.newClient();
         Response response = client.target(url("/hello/1"))
                 .request()

--- a/opentracing-jaxrs2-itest/jersey/src/test/java/io/opentracing/contrib/jaxrs2/itest/jersey/JerseyParentSpanResolutionTest.java
+++ b/opentracing-jaxrs2-itest/jersey/src/test/java/io/opentracing/contrib/jaxrs2/itest/jersey/JerseyParentSpanResolutionTest.java
@@ -1,0 +1,12 @@
+package io.opentracing.contrib.jaxrs2.itest.jersey;
+
+import io.opentracing.contrib.jaxrs2.itest.common.AbstractParentSpanResolutionTest;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+public class JerseyParentSpanResolutionTest extends AbstractParentSpanResolutionTest{
+    @Override
+    protected void initServletContext(ServletContextHandler context) {
+        super.initServletContext(context);
+        JerseyHelper.initServletContext(context);
+    }
+}

--- a/opentracing-jaxrs2-itest/resteasy/src/test/java/io/opentracing/contrib/jaxrs2/itest/resteasy/RestEasyParentSpanResolutionTest.java
+++ b/opentracing-jaxrs2-itest/resteasy/src/test/java/io/opentracing/contrib/jaxrs2/itest/resteasy/RestEasyParentSpanResolutionTest.java
@@ -1,0 +1,13 @@
+package io.opentracing.contrib.jaxrs2.itest.resteasy;
+
+import io.opentracing.contrib.jaxrs2.itest.common.AbstractParentSpanResolutionTest;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+public class RestEasyParentSpanResolutionTest extends AbstractParentSpanResolutionTest {
+
+  protected void initServletContext(ServletContextHandler context) {
+    super.initServletContext(context);
+    RestEasyHelper.initServletContext(context);
+  }
+
+}

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
@@ -9,19 +9,17 @@ import io.opentracing.contrib.jaxrs2.internal.CastUtils;
 import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
-import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.*;
 import javax.ws.rs.core.Context;
 
 /**
@@ -54,21 +52,20 @@ public class ServerTracingFilter implements ContainerRequestFilter, ContainerRes
     private HttpServletRequest httpServletRequest;
 
     @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
+    public void filter(ContainerRequestContext requestContext) {
         // return in case filter if registered twice
         if (requestContext.getProperty(PROPERTY_NAME) != null || matchesSkipPattern(requestContext)) {
             return;
         }
 
         if (tracer != null) {
-            SpanContext extractedSpanContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
-                    new ServerHeadersExtractTextMap(requestContext.getHeaders()));
 
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(operationNameProvider.operationName(requestContext))
                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
 
-            if (extractedSpanContext != null) {
-                spanBuilder.asChildOf(extractedSpanContext);
+            SpanContext parentSpanContext = parentSpanContext(requestContext);
+            if (parentSpanContext != null) {
+                spanBuilder.asChildOf(parentSpanContext);
             }
 
             Span span = spanBuilder.startActive(false).span();
@@ -92,9 +89,27 @@ public class ServerTracingFilter implements ContainerRequestFilter, ContainerRes
         }
     }
 
+    private SpanContext parentSpanContext(ContainerRequestContext requestContext) {
+        SpanContext parentSpanContext = null;
+
+        Span activeSpan = tracer.activeSpan();
+        if (activeSpan != null) {
+            parentSpanContext = activeSpan.context();
+        } else {
+            SpanContext extractedSpanContext = tracer.extract(
+                Format.Builtin.HTTP_HEADERS,
+                new ServerHeadersExtractTextMap(requestContext.getHeaders())
+            );
+            if (extractedSpanContext != null) {
+                parentSpanContext = extractedSpanContext;
+            }
+        }
+        return parentSpanContext;
+    }
+
     @Override
-    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
-            throws IOException {
+    public void filter(ContainerRequestContext requestContext,
+                       ContainerResponseContext responseContext) {
         SpanWrapper spanWrapper = CastUtils.cast(requestContext.getProperty(PROPERTY_NAME), SpanWrapper.class);
         if (spanWrapper == null) {
             return;


### PR DESCRIPTION
Proof of concept for https://github.com/opentracing-contrib/java-jaxrs/issues/67.

If there is active span already (probably initialized in a different filter, e.g. servlet filter), we should use it instead of extracting a new one from HTTP headers.

How do you think would be the best way to test that?