### PR TITLE
Pass and close scope directly

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/internal/SpanWrapper.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/internal/SpanWrapper.java
@@ -1,6 +1,8 @@
 package io.opentracing.contrib.jaxrs2.internal;
 
+import io.opentracing.Scope;
 import io.opentracing.Span;
+import java.sql.Wrapper;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -12,21 +14,25 @@ public class SpanWrapper {
 
     public static final String PROPERTY_NAME = SpanWrapper.class.getName() + ".activeSpanWrapper";
 
-    private Span span;
+    private Scope scope;
     private AtomicBoolean finished = new AtomicBoolean();
 
-    public SpanWrapper(Span span) {
-        this.span = span;
+    public SpanWrapper(Scope scope) {
+        this.scope = scope;
     }
 
     public Span get() {
-        return span;
+        return scope.span();
+    }
+
+    public Scope getScope() {
+        return scope;
     }
 
     public synchronized void finish() {
         if (!finished.get()) {
             finished.set(true);
-            span.finish();
+            scope.span().finish();
         }
     }
 

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
@@ -61,12 +61,9 @@ public class SpanFinishingFilter implements Filter {
       }
       throw ex;
     } finally {
-      Scope scope = tracer.scopeManager().active();
-      if (scope != null) {
-        scope.close();
-      }
       SpanWrapper spanWrapper = getSpanWrapper(httpRequest);
       if (spanWrapper != null) {
+        spanWrapper.getScope().close();
         if (request.isAsyncStarted()) {
           request.getAsyncContext().addListener(new SpanFinisher(spanWrapper), request, response);
         } else {


### PR DESCRIPTION
Fixes #87 

Avoid using ScopeManager.active() as some
tracer implementations return different scope
with invalid scope.close() method.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>