### PR TITLE
Reduce log verbosity on bootstrap

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingDynamicFeature.java
@@ -28,7 +28,6 @@ public class ServerTracingDynamicFeature implements DynamicFeature {
     private static final Logger log = Logger.getLogger(ServerTracingDynamicFeature.class.getName());
 
     private final Builder builder;
-    private boolean logged = false;
 
     /**
      * When using this constructor application has to call {@link GlobalTracer#register} to register
@@ -69,11 +68,7 @@ public class ServerTracingDynamicFeature implements DynamicFeature {
             log.fine(String.format("Registering tracing on %s#%s...",
                     resourceInfo.getResourceClass().getCanonicalName(),
                     resourceInfo.getResourceMethod().getName()));
-        } else if (!logged) {
-            log.info("Registering tracing on deployed resources...");
         }
-
-        logged = true;
     }
 
     protected Traced closestTracedAnnotation(ResourceInfo resourceInfo) {


### PR DESCRIPTION
On a setup with several resources, each resource causes a log entry like: 

> 16:07:03,673 INFO  [io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature] (ServerService Thread Pool -- 10) Registering tracing on deployed resources...

This message doesn't bring a lot of value, especially when it's repeated several times (one per resource). For the common case, no logging is necessary. For debugging purposes, a user can just increase the verbosity for this package (or the whole application). For that, there's a log message already.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>