### PR TITLE
Search for skipPattern in servletcontext if none is defined by Builder

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/ServerTracingFilter.java
@@ -133,7 +133,7 @@ public class ServerTracingFilter implements ContainerRequestFilter, ContainerRes
     private boolean matchesSkipPattern(ContainerRequestContext requestContext) {
         // skip URLs matching skip pattern
         // e.g. pattern is defined as '/health|/status' then URL 'http://localhost:5000/context/health' won't be traced
-        if (skipPattern == null && httpServletRequest.getServletContext() != null) {
+        if (skipPattern == null && httpServletRequest != null && httpServletRequest.getServletContext() != null) {
             Object contextAttribute = httpServletRequest.getServletContext().getAttribute(SKIP_PATTERN);
             if (contextAttribute instanceof Pattern) {
                 skipPattern = (Pattern) contextAttribute;


### PR DESCRIPTION
Allow configuration of skipPattern via a ServletContext attribute if none is define via the constructor of ServerTracingFilter (a bit like in (https://github.com/opentracing-contrib/java-web-servlet-filter/blob/master/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java)