### PR TITLE
Remove tracer from filter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ public class OpenTracingContextInitializer implements javax.servlet.ServletConte
     
     ServletContext servletContext = servletContextEvent.getServletContext();
     Dynamic filterRegistration = servletContext
-        .addFilter("tracingFilter", new SpanFinishingFilter(tracer));
+        .addFilter("tracingFilter", new SpanFinishingFilter());
     filterRegistration.setAsyncSupported(true);
     filterRegistration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST, DispatcherType.ASYNC), false, "*");
   }

--- a/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/Configuration.java
+++ b/examples/spring-boot/src/main/java/io/opentracing/contrib/jaxrs2/example/spring/boot/Configuration.java
@@ -18,9 +18,9 @@ public class Configuration {
     }
 
     @Bean
-    public FilterRegistrationBean spanFinishingFilter(Tracer tracer) {
+    public FilterRegistrationBean spanFinishingFilter() {
         FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean();
-        filterRegistrationBean.setFilter(new SpanFinishingFilter(tracer));
+        filterRegistrationBean.setFilter(new SpanFinishingFilter());
         filterRegistrationBean.setAsyncSupported(true);
         filterRegistrationBean.setDispatcherTypes(DispatcherType.REQUEST);
         filterRegistrationBean.addUrlPatterns("*");

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractClassOperationNameTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractClassOperationNameTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractClassOperationNameTest extends AbstractJettyTest {
         new ServerTracingDynamicFeature.Builder(mockTracer)
             .withOperationNameProvider(ClassNameOperationName.newBuilder())
             .build();
-    context.addFilter(new FilterHolder(new SpanFinishingFilter(mockTracer)),
+    context.addFilter(new FilterHolder(new SpanFinishingFilter()),
         "/*", EnumSet.of(DispatcherType.REQUEST));
 
     context.setAttribute(TRACER_ATTRIBUTE, mockTracer);

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractJettyTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractJettyTest {
                 .withSkipPattern("/health")
             .build();
         // TODO clarify dispatcher types
-        context.addFilter(new FilterHolder(new SpanFinishingFilter(mockTracer)), "/*",
+        context.addFilter(new FilterHolder(new SpanFinishingFilter()), "/*",
             EnumSet.of(
                 DispatcherType.REQUEST,
                 // TODO CXF does not call AsyncListener#onComplete() without this (it calls only onStartAsync)

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerDefaultConfigurationTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractServerDefaultConfigurationTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractServerDefaultConfigurationTest extends AbstractJet
         ServerTracingDynamicFeature serverTracingBuilder =
                 new ServerTracingDynamicFeature.Builder(mockTracer)
                         .build();
-        context.addFilter(new FilterHolder(new SpanFinishingFilter(mockTracer)),
+        context.addFilter(new FilterHolder(new SpanFinishingFilter()),
             "/*", EnumSet.of(DispatcherType.REQUEST));
 
         context.setAttribute(TRACER_ATTRIBUTE, mockTracer);

--- a/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
+++ b/opentracing-jaxrs2-itest/common/src/main/java/io/opentracing/contrib/jaxrs2/itest/common/AbstractWildcardOperationNameTest.java
@@ -31,7 +31,7 @@ public abstract class AbstractWildcardOperationNameTest extends AbstractJettyTes
             new ServerTracingDynamicFeature.Builder(mockTracer)
                 .withOperationNameProvider(WildcardOperationName.newBuilder())
             .build();
-        context.addFilter(new FilterHolder(new SpanFinishingFilter(mockTracer)),
+        context.addFilter(new FilterHolder(new SpanFinishingFilter()),
             "/*", EnumSet.of(DispatcherType.REQUEST));
 
         context.setAttribute(TRACER_ATTRIBUTE, mockTracer);

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
@@ -27,18 +27,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SpanFinishingFilter implements Filter {
 
-  private final Tracer tracer;
-
-  public SpanFinishingFilter() {
-    this(GlobalTracer.get());
-  }
-
-  public SpanFinishingFilter(Tracer tracer){
-    this.tracer = tracer;
-  }
-
   @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
+  public void init(FilterConfig filterConfig) {
   }
 
   @Override

--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/SpanFinishingFilter.java
@@ -5,7 +5,6 @@ import io.opentracing.Tracer;
 import io.opentracing.contrib.jaxrs2.internal.CastUtils;
 import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.opentracing.tag.Tags;
-import io.opentracing.util.GlobalTracer;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +25,17 @@ import javax.servlet.http.HttpServletResponse;
  * @author Pavol Loffay
  */
 public class SpanFinishingFilter implements Filter {
+
+  public SpanFinishingFilter() {
+  }
+
+  /**
+   * @param tracer
+   * @deprecated use no-args constructor
+   */
+  @Deprecated
+  public SpanFinishingFilter(Tracer tracer){
+  }
 
   @Override
   public void init(FilterConfig filterConfig) {


### PR DESCRIPTION
filter does not need tracer it operates on span wrapper in attributes

Signed-off-by: Pavol Loffay <ploffay@redhat.com>