### PR TITLE
Remove unused dependency

### DIFF
--- a/opentracing-jaxrs2-itest/pom.xml
+++ b/opentracing-jaxrs2-itest/pom.xml
@@ -36,10 +36,6 @@
 
     <dependency>
       <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-noop</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
     </dependency>
     <dependency>

--- a/opentracing-jaxrs2/pom.xml
+++ b/opentracing-jaxrs2/pom.xml
@@ -16,11 +16,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-noop</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-web-servlet-filter</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
 
       <dependency>
         <groupId>io.opentracing</groupId>
-        <artifactId>opentracing-noop</artifactId>
-        <version>${version.io.opentracing-opentracing}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.opentracing</groupId>
         <artifactId>opentracing-mock</artifactId>
         <version>${version.io.opentracing-opentracing}</version>
       </dependency>


### PR DESCRIPTION
The `opentracing-noop` dependency is not necessary.