### PR TITLE
Performance Improvements

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/OperationNameProvider.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/server/OperationNameProvider.java
@@ -55,12 +55,12 @@ public interface OperationNameProvider {
 
     private String classMethod;
     ClassNameOperationName(Class<?> clazz, Method method) {
-      this.classMethod = String.format("%s.%s", clazz.getName() , method.getName());
+      this.classMethod = clazz.getName()  + "." + method.getName();
     }
 
     @Override
     public String operationName(ContainerRequestContext requestContext) {
-      return String.format("%s:%s", requestContext.getMethod(), classMethod);
+      return requestContext.getMethod() + ":" + classMethod;
     }
 
     public static Builder newBuilder() {


### PR DESCRIPTION
A flame graph of a load test pointed out a lot of CPU cycles on these String.formats. JMH shows that String.format is 40X slower than a plain concat of the 3 strings