### PR TITLE
Remove unneeded synchronized on SpanWrapper.finish

### DIFF
--- a/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/internal/SpanWrapper.java
+++ b/opentracing-jaxrs2/src/main/java/io/opentracing/contrib/jaxrs2/internal/SpanWrapper.java
@@ -31,9 +31,8 @@ public class SpanWrapper {
         return scope;
     }
 
-    public synchronized void finish() {
-        if (!finished.get()) {
-            finished.set(true);
+    public void finish() {
+        if (finished.compareAndSet(false, true)) {
             span.finish();
         }
     }


### PR DESCRIPTION
Make use of the already available AtomicBoolean primitives to be lock
free